### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/DGElasticPullToRefresh/DGElasticPullToRefreshConstants.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshConstants.swift
@@ -35,9 +35,9 @@ public struct DGElasticPullToRefreshConstants {
         static let PanGestureRecognizerState = "panGestureRecognizer.state"
     }
     
-    static let WaveMaxHeight: CGFloat = 70.0
-    static let MinOffsetToPull: CGFloat = 95.0
-    static let LoadingContentInset: CGFloat = 50.0
-    static let LoadingViewSize: CGFloat = 30.0
-    
+    public static var WaveMaxHeight: CGFloat = 70.0
+    public static var MinOffsetToPull: CGFloat = 95.0
+    public static var LoadingContentInset: CGFloat = 50.0
+    public static var LoadingViewSize: CGFloat = 30.0
+	
 }

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
@@ -130,6 +130,7 @@ public extension UIScrollView {
     public func dg_removePullToRefresh() {
         pullToRefreshView.observing = false
         pullToRefreshView.removeFromSuperview()
+        _pullToRefreshView = nil // remove associated object, otherwise it doesn't get deallocated
     }
     
     public func dg_setPullToRefreshBackgroundColor(color: UIColor) {

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
@@ -116,10 +116,6 @@ public extension UIScrollView {
     // MARK: -
     // MARK: Methods (Public)
     
-    public func dg_addPullToRefreshWithActionHandler(actionHandler: () -> Void) {
-        dg_addPullToRefreshWithActionHandler(actionHandler, loadingView: nil)
-    }
-    
     public func dg_addPullToRefreshWithActionHandler(actionHandler: () -> Void, loadingView: DGElasticPullToRefreshLoadingView?) {
         multipleTouchEnabled = false
         panGestureRecognizer.maximumNumberOfTouches = 1
@@ -147,14 +143,6 @@ public extension UIScrollView {
     public func dg_stopLoading() {
         pullToRefreshView.stopLoading()
     }
-    
-    func dg_stopScrollingAnimation() {
-        if let superview = self.superview, let index = superview.subviews.indexOf({ $0 == self }) as Int! {
-            removeFromSuperview()
-            superview.insertSubview(self, atIndex: index)
-        }
-    }
-    
 }
 
 // MARK: -

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshExtensions.swift
@@ -81,68 +81,53 @@ public extension NSObject {
 
 public extension UIScrollView {
     
-    // MARK: -
-    // MARK: Vars
-    
+    // MARK: - Vars
+
     private struct dg_associatedKeys {
         static var pullToRefreshView = "pullToRefreshView"
     }
-    
-    private var _pullToRefreshView: DGElasticPullToRefreshView? {
+
+    private var pullToRefreshView: DGElasticPullToRefreshView? {
         get {
-            if let pullToRefreshView = objc_getAssociatedObject(self, &dg_associatedKeys.pullToRefreshView) as? DGElasticPullToRefreshView {
-                return pullToRefreshView
-            }
-            
-            return nil
+            return objc_getAssociatedObject(self, &dg_associatedKeys.pullToRefreshView) as? DGElasticPullToRefreshView
         }
+
         set {
             objc_setAssociatedObject(self, &dg_associatedKeys.pullToRefreshView, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
     
-    private var pullToRefreshView: DGElasticPullToRefreshView! {
-        get {
-            if let pullToRefreshView = _pullToRefreshView {
-                return pullToRefreshView
-            } else {
-                let pullToRefreshView = DGElasticPullToRefreshView()
-                _pullToRefreshView = pullToRefreshView
-                return pullToRefreshView
-            }
-        }
-    }
-    
-    // MARK: -
-    // MARK: Methods (Public)
+    // MARK: - Methods (Public)
     
     public func dg_addPullToRefreshWithActionHandler(actionHandler: () -> Void, loadingView: DGElasticPullToRefreshLoadingView?) {
         multipleTouchEnabled = false
         panGestureRecognizer.maximumNumberOfTouches = 1
-        
+
+        let pullToRefreshView = DGElasticPullToRefreshView()
+        self.pullToRefreshView = pullToRefreshView
         pullToRefreshView.actionHandler = actionHandler
         pullToRefreshView.loadingView = loadingView
         addSubview(pullToRefreshView)
-        
+
         pullToRefreshView.observing = true
     }
     
     public func dg_removePullToRefresh() {
-        pullToRefreshView.observing = false
-        pullToRefreshView.removeFromSuperview()
-        _pullToRefreshView = nil // remove associated object, otherwise it doesn't get deallocated
+        pullToRefreshView?.disassociateDisplayLink()
+        pullToRefreshView?.observing = false
+        pullToRefreshView?.removeFromSuperview()
     }
     
     public func dg_setPullToRefreshBackgroundColor(color: UIColor) {
-        pullToRefreshView.backgroundColor = color
+        pullToRefreshView?.backgroundColor = color
     }
     
     public func dg_setPullToRefreshFillColor(color: UIColor) {
-        pullToRefreshView.fillColor = color
+        pullToRefreshView?.fillColor = color
     }
     
     public func dg_stopLoading() {
-        pullToRefreshView.stopLoading()
+        pullToRefreshView?.stopLoading()
     }
 }
 

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
@@ -313,25 +313,29 @@ public class DGElasticPullToRefreshView: UIView {
         startDisplayLink()
         scrollView.dg_removeObserver(self, forKeyPath: DGElasticPullToRefreshConstants.KeyPaths.ContentOffset)
         scrollView.dg_removeObserver(self, forKeyPath: DGElasticPullToRefreshConstants.KeyPaths.ContentInset)
-        UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: 0.43, initialSpringVelocity: 0.0, options: [], animations: { () -> Void in
-            self.cControlPointView.center.y = centerY
-            self.l1ControlPointView.center.y = centerY
-            self.l2ControlPointView.center.y = centerY
-            self.l3ControlPointView.center.y = centerY
-            self.r1ControlPointView.center.y = centerY
-            self.r2ControlPointView.center.y = centerY
-            self.r3ControlPointView.center.y = centerY
-            }, completion: { _ in
-                self.stopDisplayLink()
-                self.resetScrollViewContentInset(shouldAddObserverWhenFinished: true, animated: false, completion: nil)
-                scrollView.dg_addObserver(self, forKeyPath: DGElasticPullToRefreshConstants.KeyPaths.ContentOffset)
-                scrollView.scrollEnabled = true
-                self.state = .Loading
-        })
+        UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: 0.43, initialSpringVelocity: 0.0, options: [], animations: { [weak self] in
+            self?.cControlPointView.center.y = centerY
+            self?.l1ControlPointView.center.y = centerY
+            self?.l2ControlPointView.center.y = centerY
+            self?.l3ControlPointView.center.y = centerY
+            self?.r1ControlPointView.center.y = centerY
+            self?.r2ControlPointView.center.y = centerY
+            self?.r3ControlPointView.center.y = centerY
+            }, completion: { [weak self] _ in
+                self?.stopDisplayLink()
+                self?.resetScrollViewContentInset(shouldAddObserverWhenFinished: true, animated: false, completion: nil)
+                if let strongSelf = self, scrollView = strongSelf.scrollView() {
+                    scrollView.dg_addObserver(strongSelf, forKeyPath: DGElasticPullToRefreshConstants.KeyPaths.ContentOffset)
+                    scrollView.scrollEnabled = true
+                }
+                self?.state = .Loading
+            })
         
         bounceAnimationHelperView.center = CGPoint(x: 0.0, y: originalContentInsetTop + currentHeight())
-        UIView.animateWithDuration(duration * 0.4, animations: { () -> Void in
-            self.bounceAnimationHelperView.center = CGPoint(x: 0.0, y: self.originalContentInsetTop + DGElasticPullToRefreshConstants.LoadingContentInset)
+        UIView.animateWithDuration(duration * 0.4, animations: { [weak self] in
+            if let contentInsetTop = self?.originalContentInsetTop {
+                self?.bounceAnimationHelperView.center = CGPoint(x: 0.0, y: contentInsetTop + DGElasticPullToRefreshConstants.LoadingContentInset)
+            }
             }, completion: nil)
     }
     

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
@@ -162,7 +162,6 @@ public class DGElasticPullToRefreshView: UIView {
         if keyPath == DGElasticPullToRefreshConstants.KeyPaths.ContentOffset {
             if let newContentOffsetY = change?[NSKeyValueChangeNewKey]?.CGPointValue.y, let scrollView = scrollView() {
                 if state.isAnyOf([.Loading, .AnimatingToStopped]) && newContentOffsetY < -scrollView.contentInset.top {
-                    scrollView.dg_stopScrollingAnimation()
                     scrollView.contentOffset.y = -scrollView.contentInset.top
                 } else {
                     scrollViewDidChangeContentOffset(dragging: scrollView.dragging)
@@ -252,7 +251,6 @@ public class DGElasticPullToRefreshView: UIView {
         } else if state == .Dragging && dragging == false {
             if offsetY >= DGElasticPullToRefreshConstants.MinOffsetToPull {
                 state = .AnimatingBounce
-                scrollView()?.dg_stopScrollingAnimation()
             } else {
                 state = .Stopped
             }
@@ -278,7 +276,7 @@ public class DGElasticPullToRefreshView: UIView {
         
         let animationBlock = { scrollView.contentInset = contentInset }
         let completionBlock = { () -> Void in
-            if shouldAddObserverWhenFinished {
+            if shouldAddObserverWhenFinished && self.observing {
                 scrollView.dg_addObserver(self, forKeyPath: DGElasticPullToRefreshConstants.KeyPaths.ContentInset)
             }
             completion?()

--- a/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
+++ b/DGElasticPullToRefresh/DGElasticPullToRefreshView.swift
@@ -149,7 +149,14 @@ public class DGElasticPullToRefreshView: UIView {
     }
     
     // MARK: -
-    
+
+    /**
+    Has to be called when the receiver is no longer required. Otherwise the main loop holds a reference to the receiver which in turn will prevent the receiver from being deallocated.
+    */
+    func disassociateDisplayLink() {
+        displayLink?.invalidate()
+    }
+
     deinit {
         observing = false
         NSNotificationCenter.defaultCenter().removeObserver(self)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open and run the DGElasticPullToRefreshExample project in Xcode to see DGElastic
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 
 ``` ruby
 pod "DGElasticPullToRefresh"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Remove pull to refresh:
 func dg_removePullToRefresh()
 ```
 
+Set auto start loading:
+
+``` swift
+func dg_startLoading()
+```
+
 Change pull to refresh background color:
 
 ``` swift


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
